### PR TITLE
update for mix v6

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ mix.extend('mergeManifest', (config) => {
     config.plugins.push(new class {
         apply(compiler) {
 
-            compiler.plugin('emit', (curCompiler, callback) => {
+            compiler.hooks.emit.tapAsync('ManifestPlugin', (curCompiler, callback) => {
                 let stats = curCompiler.getStats().toJson();
 
                 try {


### PR DESCRIPTION
Since mix v6 uses webpack 5, this needs to be updated to work with it.

* old mix versions will not work with this..